### PR TITLE
Import config at build time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const withMarkdoc =
               options: {
                 ...pluginOptions,
                 dir: options.dir,
+                nextRuntime: options.nextRuntime,
               },
             },
           ],

--- a/src/loader.js
+++ b/src/loader.js
@@ -75,6 +75,7 @@ async function load(source) {
     global.$RefreshReg$ = noop;
     global.$RefreshSig$ = () => noop;
 
+    // This imports the config as an in-memory object
     const importAtBuildTime = async (resource) => {
       try {
         const object = await this.importModule(
@@ -162,6 +163,7 @@ async function load(source) {
   try {
     const directoryExists = await fs.promises.stat(schemaDir);
 
+    // This creates import strings that cause the config to be imported runtime
     async function importAtRuntime(variable) {
       try {
         const module = await resolve(schemaDir, variable);

--- a/src/loader.js
+++ b/src/loader.js
@@ -40,7 +40,6 @@ async function gatherPartials(ast, schemaDir) {
 
 // Returning a JSX object is what allows fast refresh to work
 async function load(source) {
-  const logger = this.getLogger('@markdoc/next.js');
   // https://webpack.js.org/concepts/module-resolution/
   const resolve = this.getResolve({
     // https://webpack.js.org/api/loaders/#thisgetresolve
@@ -99,19 +98,19 @@ async function load(source) {
         case 'debug':
         case 'error':
         case 'info': {
-          logger[e.error.level](e.error.message);
+          console[e.error.level](e.error.message);
           break;
         }
         case 'warning': {
-          logger.warn(e.error.message);
+          console.warn(e.error.message);
           break;
         }
         case 'critical': {
-          logger.error(e.error.message);
+          console.error(e.error.message);
           break;
         }
         default: {
-          logger.log(e.error.message);
+          console.log(e.error.message);
           break;
         }
       }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -65,6 +65,7 @@ function options(config = {}) {
       return {
         ...config,
         dir: __dirname,
+        nextRuntime: 'nodejs',
       };
     },
     getLogger() {


### PR DESCRIPTION
By importing the config at build time, we are able to run `Markdoc.validate` with the config that will be used at runtime. 

Closes markdoc/markdoc#129