### PR TITLE
Fix default export warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
       "devDependencies": {
         "@babel/core": "^7.16.12",
         "@babel/plugin-transform-modules-commonjs": "^7.16.8",
-        "@markdoc/markdoc": "^0.1.1",
+        "@markdoc/markdoc": "*",
         "@types/jest": "^27.4.1",
         "enhanced-resolve": "^5.10.0",
         "jest": "^27.5.1",
+        "next": "*",
+        "react": "*",
         "ts-jest": "^27.1.3",
         "typescript": "4.6.2"
       },
@@ -1201,9 +1203,9 @@
       }
     },
     "node_modules/@markdoc/markdoc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.1.1.tgz",
-      "integrity": "sha512-ak7lacwM9fY99U+b9+IQ02qkcdc8Of0OPIWUdWNHW8zdmWam0fNRYoKWVR1B5OvdWDauYN3u0+ZbR9cds3oChw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.1.7.tgz",
+      "integrity": "sha512-Dz7+VP5I3m/DFpLnzjwvXv64XmneYNzy4adm5uJSkcAJxFlJujIn+hCmMh11k70w+y5Qu18sjngetpuP+3570g==",
       "dev": true,
       "engines": {
         "node": ">=14.7.0"
@@ -1213,7 +1215,7 @@
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.6.tgz",
       "integrity": "sha512-Te/OBDXFSodPU6jlXYPAXpmZr/AkG6DCATAxttQxqOWaq6eDFX25Db3dK0120GZrSZmv4QCe9KsZmJKDbWs4OA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@next/swc-android-arm-eabi": {
       "version": "12.1.6",
@@ -1222,11 +1224,11 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1238,11 +1240,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1254,11 +1256,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1270,11 +1272,11 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1286,11 +1288,11 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1302,11 +1304,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1318,11 +1320,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1334,11 +1336,11 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1350,11 +1352,11 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1366,11 +1368,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1382,11 +1384,11 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1398,11 +1400,11 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1968,6 +1970,7 @@
       "version": "1.0.30001339",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
       "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4588,7 +4591,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4742,7 +4746,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -4863,7 +4867,7 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "peer": true,
+      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4881,7 +4885,7 @@
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/next/-/next-12.1.6.tgz",
       "integrity": "sha512-cebwKxL3/DhNKfg9tPZDQmbRKjueqykHHbgaoG4VBRH3AHQJ2HO0dbKFiS1hPhe1/qgc2d/hFeadsbPicmLD+A==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@next/env": "12.1.6",
         "caniuse-lite": "^1.0.30001332",
@@ -5130,7 +5134,8 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -5169,7 +5174,7 @@
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
       "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
@@ -5250,7 +5255,7 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
       "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5262,6 +5267,7 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
       "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -5376,6 +5382,7 @@
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
       "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -5445,7 +5452,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5560,7 +5567,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
       "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7007,100 +7014,100 @@
       }
     },
     "@markdoc/markdoc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.1.1.tgz",
-      "integrity": "sha512-ak7lacwM9fY99U+b9+IQ02qkcdc8Of0OPIWUdWNHW8zdmWam0fNRYoKWVR1B5OvdWDauYN3u0+ZbR9cds3oChw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.1.7.tgz",
+      "integrity": "sha512-Dz7+VP5I3m/DFpLnzjwvXv64XmneYNzy4adm5uJSkcAJxFlJujIn+hCmMh11k70w+y5Qu18sjngetpuP+3570g==",
       "dev": true
     },
     "@next/env": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.6.tgz",
       "integrity": "sha512-Te/OBDXFSodPU6jlXYPAXpmZr/AkG6DCATAxttQxqOWaq6eDFX25Db3dK0120GZrSZmv4QCe9KsZmJKDbWs4OA==",
-      "peer": true
+      "dev": true
     },
     "@next/swc-android-arm-eabi": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.6.tgz",
       "integrity": "sha512-BxBr3QAAAXWgk/K7EedvzxJr2dE014mghBSA9iOEAv0bMgF+MRq4PoASjuHi15M2zfowpcRG8XQhMFtxftCleQ==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-android-arm64": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.6.tgz",
       "integrity": "sha512-EboEk3ROYY7U6WA2RrMt/cXXMokUTXXfnxe2+CU+DOahvbrO8QSWhlBl9I9ZbFzJx28AGB9Yo3oQHCvph/4Lew==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-darwin-arm64": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.6.tgz",
       "integrity": "sha512-P0EXU12BMSdNj1F7vdkP/VrYDuCNwBExtRPDYawgSUakzi6qP0iKJpya2BuLvNzXx+XPU49GFuDC5X+SvY0mOw==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-darwin-x64": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.6.tgz",
       "integrity": "sha512-9FptMnbgHJK3dRDzfTpexs9S2hGpzOQxSQbe8omz6Pcl7rnEp9x4uSEKY51ho85JCjL4d0tDLBcXEJZKKLzxNg==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.6.tgz",
       "integrity": "sha512-PvfEa1RR55dsik/IDkCKSFkk6ODNGJqPY3ysVUZqmnWMDSuqFtf7BPWHFa/53znpvVB5XaJ5Z1/6aR5CTIqxPw==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.6.tgz",
       "integrity": "sha512-53QOvX1jBbC2ctnmWHyRhMajGq7QZfl974WYlwclXarVV418X7ed7o/EzGY+YVAEKzIVaAB9JFFWGXn8WWo0gQ==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-arm64-musl": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.6.tgz",
       "integrity": "sha512-CMWAkYqfGdQCS+uuMA1A2UhOfcUYeoqnTW7msLr2RyYAys15pD960hlDfq7QAi8BCAKk0sQ2rjsl0iqMyziohQ==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-x64-gnu": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.6.tgz",
       "integrity": "sha512-AC7jE4Fxpn0s3ujngClIDTiEM/CQiB2N2vkcyWWn6734AmGT03Duq6RYtPMymFobDdAtZGFZd5nR95WjPzbZAQ==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-x64-musl": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.6.tgz",
       "integrity": "sha512-c9Vjmi0EVk0Kou2qbrynskVarnFwfYIi+wKufR9Ad7/IKKuP6aEhOdZiIIdKsYWRtK2IWRF3h3YmdnEa2WLUag==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.6.tgz",
       "integrity": "sha512-3UTOL/5XZSKFelM7qN0it35o3Cegm6LsyuERR3/OoqEExyj3aCk7F025b54/707HTMAnjlvQK3DzLhPu/xxO4g==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.6.tgz",
       "integrity": "sha512-8ZWoj6nCq6fI1yCzKq6oK0jE6Mxlz4MrEsRyu0TwDztWQWe7rh4XXGLAa2YVPatYcHhMcUL+fQQbqd1MsgaSDA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-win32-x64-msvc": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.6.tgz",
       "integrity": "sha512-4ZEwiRuZEicXhXqmhw3+de8Z4EpOLQj/gp+D9fFWo6ii6W1kBkNNvvEx4A90ugppu+74pT1lIJnOuz3A9oQeJA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -7557,7 +7564,8 @@
     "caniuse-lite": {
       "version": "1.0.30001339",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
-      "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ=="
+      "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -9517,7 +9525,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -9633,7 +9642,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -9727,7 +9736,7 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "peer": true
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -9739,7 +9748,7 @@
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/next/-/next-12.1.6.tgz",
       "integrity": "sha512-cebwKxL3/DhNKfg9tPZDQmbRKjueqykHHbgaoG4VBRH3AHQJ2HO0dbKFiS1hPhe1/qgc2d/hFeadsbPicmLD+A==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@next/env": "12.1.6",
         "@next/swc-android-arm-eabi": "12.1.6",
@@ -9911,7 +9920,8 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
@@ -9938,7 +9948,7 @@
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
       "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
@@ -9996,7 +10006,7 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
       "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -10005,6 +10015,7 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
       "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
+      "dev": true,
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -10089,6 +10100,7 @@
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
       "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
+      "dev": true,
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
@@ -10143,7 +10155,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "peer": true
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.21",
@@ -10230,7 +10242,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
       "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-      "peer": true,
+      "dev": true,
       "requires": {}
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   "devDependencies": {
     "@babel/core": "^7.16.12",
     "@babel/plugin-transform-modules-commonjs": "^7.16.8",
-    "@markdoc/markdoc": "^0.1.1",
+    "@markdoc/markdoc": "*",
     "@types/jest": "^27.4.1",
     "enhanced-resolve": "^5.10.0",
     "jest": "^27.5.1",
+    "next": "*",
+    "react": "*",
     "ts-jest": "^27.1.3",
     "typescript": "4.6.2"
   },

--- a/src/loader.js
+++ b/src/loader.js
@@ -180,10 +180,10 @@ async function load(source) {
         ${await importAtRuntime('nodes')}
         ${await importAtRuntime('functions')}
         const schema = {
-          tags: tags ? (tags.default || tags) : {},
-          nodes: nodes ? (nodes.default || nodes) : {},
-          functions: functions ? (functions.default || functions) : {},
-          ...(config ? (config.default || config) : {}),
+          tags: defaultObject(tags),
+          nodes: defaultObject(nodes),
+          functions: defaultObject(functions),
+          ...defaultObject(config),
         };`
         .trim()
         .replace(/^\s+/gm, '');
@@ -201,7 +201,9 @@ import yaml from 'js-yaml';
 // renderers is imported separately so Markdoc isn't sent to the client
 import Markdoc, {renderers} from '@markdoc/markdoc'
 
-import {getSchema} from '${normalize(await resolve(__dirname, './runtime'))}';
+import {getSchema, defaultObject} from '${normalize(
+    await resolve(__dirname, './runtime')
+  )}';
 /**
  * Schema is imported like this so end-user's code is compiled using build-in babel/webpack configs.
  * This enables typescript/ESnext support

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -52,3 +52,8 @@ exports.getSchema = function getSchema(schema) {
     },
   };
 };
+
+exports.defaultObject = function defaultObject(o) {
+  if (Object.prototype.hasOwnProperty.call(o, 'default')) return o.default;
+  return o || {};
+};

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -6,7 +6,7 @@ import yaml from 'js-yaml';
 // renderers is imported separately so Markdoc isn't sent to the client
 import Markdoc, {renderers} from '@markdoc/markdoc'
 
-import {getSchema} from './src/runtime.js';
+import {getSchema, defaultObject} from './src/runtime.js';
 /**
  * Schema is imported like this so end-user's code is compiled using build-in babel/webpack configs.
  * This enables typescript/ESnext support
@@ -92,7 +92,7 @@ import yaml from 'js-yaml';
 // renderers is imported separately so Markdoc isn't sent to the client
 import Markdoc, {renderers} from '@markdoc/markdoc'
 
-import {getSchema} from './src/runtime.js';
+import {getSchema, defaultObject} from './src/runtime.js';
 /**
  * Schema is imported like this so end-user's code is compiled using build-in babel/webpack configs.
  * This enables typescript/ESnext support


### PR DESCRIPTION
This PR changes it such that `.default` is only executed if the module object has a `default` property.

Closes https://github.com/markdoc/markdoc/issues/196