### PR TITLE
Bump peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript": "4.6.2"
   },
   "peerDependencies": {
-    "@markdoc/markdoc": "^0.1.4",
+    "@markdoc/markdoc": "^0.2.0",
     "next": "*",
     "react": "*"
   },


### PR DESCRIPTION
Hi, ` "@markdoc/markdoc": "^0.1.4"` is causing`Conflicting peer dependency` error when running `npm i` with npm 7 and above. I have to run `npm i -f` every time I install or update something, which is a little annoying.

```shell
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: @markdoc/next.js@0.2.0
npm ERR! Found: @markdoc/markdoc@0.2.0
npm ERR! [node_modules/@markdoc](mailto:node_modules/@markdoc)/markdoc
npm ERR!   @markdoc/markdoc@"^0.2.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @markdoc/markdoc@"^0.1.4" from @markdoc/next.js@0.2.0
npm ERR! [node_modules/@markdoc](mailto:node_modules/@markdoc)/next.js
npm ERR!   @markdoc/next.js@"^0.2.0" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: @markdoc/markdoc@0.1.13
npm ERR! [node_modules/@markdoc](mailto:node_modules/@markdoc)/markdoc
npm ERR!   peer @markdoc/markdoc@"^0.1.4" from @markdoc/next.js@0.2.0
npm ERR!   [node_modules/@markdoc](mailto:node_modules/@markdoc)/next.js
npm ERR!     @markdoc/next.js@"^0.2.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```