### PR TITLE
0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/next.js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/next.js",
-      "version": "0.1.7-1",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -24,7 +24,7 @@
         "typescript": "4.6.2"
       },
       "peerDependencies": {
-        "@markdoc/markdoc": "^0.1.4",
+        "@markdoc/markdoc": "*",
         "next": "*",
         "react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdoc/next.js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Stripe, Inc.",
   "description": "Markdoc plugin for Next.js",
   "license": "MIT",
@@ -29,7 +29,7 @@
     "typescript": "4.6.2"
   },
   "peerDependencies": {
-    "@markdoc/markdoc": "^0.1.4",
+    "@markdoc/markdoc": "*",
     "next": "*",
     "react": "*"
   },


### PR DESCRIPTION
* Bump version to 0.2.1
* Make `@markdoc/markdoc` peer dependency to `*`

PTAL @rpaul-stripe 


Closes https://github.com/markdoc/next.js/pull/20