### PR TITLE
Add app router support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const withMarkdoc =
                 ...pluginOptions,
                 dir: options.dir,
                 nextRuntime: options.nextRuntime,
+                appDir: options.config.experimental.appDir,
               },
             },
           ],

--- a/src/loader.js
+++ b/src/loader.js
@@ -201,8 +201,6 @@ ${appDir ? '' : `export async function ${dataFetchingFunction}(context) {
   };
 }`}
 
-${appDir ? `export const metadata = frontmatter.metadata;` : ''}
-
 export default${appDir ? ' async' : ''} function MarkdocComponent(${appDir ? '' : 'props'}) {
   ${appDir ? `const props = await getProps();` : ''}
   // Only execute HMR code in development

--- a/src/loader.js
+++ b/src/loader.js
@@ -155,7 +155,7 @@ const frontmatter = ast.attributes.frontmatter
 
 const {components, ...rest} = getSchema(schema)
 
-async function getProps(context = {}) {
+async function getMarkdocData(context = {}) {
   const partials = ${JSON.stringify(partials)};
 
   // Ensure Node.transformChildren is available
@@ -186,12 +186,10 @@ async function getProps(context = {}) {
   // Removes undefined
   return JSON.parse(
     JSON.stringify({
-      markdoc: {
-        content,
-        frontmatter,
-        file: {
-          path: filepath
-        }
+      content,
+      frontmatter,
+      file: {
+        path: filepath,
       },
     })
   );
@@ -199,14 +197,16 @@ async function getProps(context = {}) {
 
 ${appDir ? '' : `export async function ${dataFetchingFunction}(context) {
   return {
-    props: await getProps(context),
+    props: {
+      markdoc: await getMarkdocData(context),
+    },
   };
 }`}
 
-export default${appDir ? ' async' : ''} function MarkdocComponent(${appDir ? '' : 'props'}) {
-  ${appDir ? `const props = await getProps();` : ''}
+export default${appDir ? ' async' : ''} function MarkdocComponent(props = {}) {
+  const markdoc = ${appDir ? 'await getMarkdocData()' : 'props.markdoc'};
   // Only execute HMR code in development
-  return renderers.react(props.markdoc.content, React, {
+  return renderers.react(markdoc.content, React, {
     components: {
       ...components,
       // Allows users to override default components at runtime, via their _app

--- a/src/loader.js
+++ b/src/loader.js
@@ -201,6 +201,8 @@ ${appDir ? '' : `export async function ${dataFetchingFunction}(context) {
   };
 }`}
 
+${appDir ? `export const metadata = frontmatter.metadata;` : ''}
+
 export default${appDir ? ' async' : ''} function MarkdocComponent(${appDir ? '' : 'props'}) {
   ${appDir ? `const props = await getProps();` : ''}
   // Only execute HMR code in development

--- a/src/loader.js
+++ b/src/loader.js
@@ -203,7 +203,7 @@ ${appDir ? '' : `export async function ${dataFetchingFunction}(context) {
   };
 }`}
 
-export default${appDir ? ' async' : ''} function MarkdocComponent(props = {}) {
+export default${appDir ? ' async' : ''} function MarkdocComponent(props) {
   const markdoc = ${appDir ? 'await getMarkdocData()' : 'props.markdoc'};
   // Only execute HMR code in development
   return renderers.react(markdoc.content, React, {

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -33,7 +33,7 @@ const frontmatter = ast.attributes.frontmatter
 
 const {components, ...rest} = getSchema(schema)
 
-export async function getStaticProps(context) {
+async function getProps(context = {}) {
   const partials = {};
 
   // Ensure Node.transformChildren is available
@@ -61,23 +61,119 @@ export async function getStaticProps(context) {
    */
   const content = await Markdoc.transform(ast, cfg);
 
+  // Removes undefined
+  return JSON.parse(
+    JSON.stringify({
+      markdoc: {
+        content,
+        frontmatter,
+        file: {
+          path: filepath
+        }
+      },
+    })
+  );
+}
+
+export async function getStaticProps(context) {
   return {
-    // Removes undefined
-    props: JSON.parse(
-      JSON.stringify({
-        markdoc: {
-          content,
-          frontmatter,
-          file: {
-            path: filepath
-          }
-        },
-      })
-    ),
+    props: await getProps(context),
   };
 }
 
 export default function MarkdocComponent(props) {
+  
+  // Only execute HMR code in development
+  return renderers.react(props.markdoc.content, React, {
+    components: {
+      ...components,
+      // Allows users to override default components at runtime, via their _app
+      ...props.components,
+    },
+  });
+}
+"
+`;
+
+exports[`app router 1`] = `
+"import React from 'react';
+import yaml from 'js-yaml';
+// renderers is imported separately so Markdoc isn't sent to the client
+import Markdoc, {renderers} from '@markdoc/markdoc'
+
+import {getSchema, defaultObject} from './src/runtime.js';
+/**
+ * Schema is imported like this so end-user's code is compiled using build-in babel/webpack configs.
+ * This enables typescript/ESnext support
+ */
+const schema = {};
+
+const tokenizer = new Markdoc.Tokenizer({\\"allowComments\\":true});
+
+/**
+ * Source will never change at runtime, so parse happens at the file root
+ */
+const source = \\"---\\\\ntitle: Custom title\\\\n---\\\\n\\\\n# {% $markdoc.frontmatter.title %}\\\\n\\\\n{% tag /%}\\\\n\\";
+const filepath = undefined;
+const tokens = tokenizer.tokenize(source);
+const ast = Markdoc.parse(tokens);
+
+/**
+ * Like the AST, frontmatter won't change at runtime, so it is loaded at file root.
+ * This unblocks future features, such a per-page dataFetchingFunction.
+ */
+const frontmatter = ast.attributes.frontmatter
+  ? yaml.load(ast.attributes.frontmatter)
+  : {};
+
+const {components, ...rest} = getSchema(schema)
+
+async function getProps(context = {}) {
+  const partials = {};
+
+  // Ensure Node.transformChildren is available
+  Object.keys(partials).forEach((key) => {
+    const tokens = tokenizer.tokenize(partials[key]);
+    partials[key] = Markdoc.parse(tokens);
+  });
+
+  const cfg = {
+    ...rest,
+    variables: {
+      ...(rest ? rest.variables : {}),
+      // user can't override this namespace
+      markdoc: {frontmatter},
+      // Allows users to eject from Markdoc rendering and pass in dynamic variables via getServerSideProps
+      ...(context.variables || {})
+    },
+    partials,
+    source,
+  };
+
+  /**
+   * transform must be called in dataFetchingFunction to support server-side rendering while
+   * accessing variables on the server
+   */
+  const content = await Markdoc.transform(ast, cfg);
+
+  // Removes undefined
+  return JSON.parse(
+    JSON.stringify({
+      markdoc: {
+        content,
+        frontmatter,
+        file: {
+          path: filepath
+        }
+      },
+    })
+  );
+}
+
+
+
+export default async function MarkdocComponent() {
+  const props = await getProps();
   // Only execute HMR code in development
   return renderers.react(props.markdoc.content, React, {
     components: {
@@ -123,7 +219,7 @@ const frontmatter = ast.attributes.frontmatter
 
 const {components, ...rest} = getSchema(schema)
 
-export async function getStaticProps(context) {
+async function getProps(context = {}) {
   const partials = {};
 
   // Ensure Node.transformChildren is available
@@ -151,23 +247,28 @@ export async function getStaticProps(context) {
    */
   const content = await Markdoc.transform(ast, cfg);
 
+  // Removes undefined
+  return JSON.parse(
+    JSON.stringify({
+      markdoc: {
+        content,
+        frontmatter,
+        file: {
+          path: filepath
+        }
+      },
+    })
+  );
+}
+
+export async function getStaticProps(context) {
   return {
-    // Removes undefined
-    props: JSON.parse(
-      JSON.stringify({
-        markdoc: {
-          content,
-          frontmatter,
-          file: {
-            path: filepath
-          }
-        },
-      })
-    ),
+    props: await getProps(context),
   };
 }
 
 export default function MarkdocComponent(props) {
+  
   // Only execute HMR code in development
   return renderers.react(props.markdoc.content, React, {
     components: {

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -33,7 +33,7 @@ const frontmatter = ast.attributes.frontmatter
 
 const {components, ...rest} = getSchema(schema)
 
-async function getProps(context = {}) {
+async function getMarkdocData(context = {}) {
   const partials = {};
 
   // Ensure Node.transformChildren is available
@@ -64,12 +64,10 @@ async function getProps(context = {}) {
   // Removes undefined
   return JSON.parse(
     JSON.stringify({
-      markdoc: {
-        content,
-        frontmatter,
-        file: {
-          path: filepath
-        }
+      content,
+      frontmatter,
+      file: {
+        path: filepath,
       },
     })
   );
@@ -77,14 +75,16 @@ async function getProps(context = {}) {
 
 export async function getStaticProps(context) {
   return {
-    props: await getProps(context),
+    props: {
+      markdoc: await getMarkdocData(context),
+    },
   };
 }
 
-export default function MarkdocComponent(props) {
-  
+export default function MarkdocComponent(props = {}) {
+  const markdoc = props.markdoc;
   // Only execute HMR code in development
-  return renderers.react(props.markdoc.content, React, {
+  return renderers.react(markdoc.content, React, {
     components: {
       ...components,
       // Allows users to override default components at runtime, via their _app
@@ -116,7 +116,7 @@ const tokenizer = new Markdoc.Tokenizer({\\"allowComments\\":true});
 const source = \\"---\\\\ntitle: Custom title\\\\n---\\\\n\\\\n# {% $markdoc.frontmatter.title %}\\\\n\\\\n{% tag /%}\\\\n\\";
 const filepath = undefined;
 const tokens = tokenizer.tokenize(source);
-const ast = Markdoc.parse(tokens);
+const ast = Markdoc.parse(tokens, {slots: false});
 
 /**
  * Like the AST, frontmatter won't change at runtime, so it is loaded at file root.
@@ -128,7 +128,7 @@ const frontmatter = ast.attributes.frontmatter
 
 const {components, ...rest} = getSchema(schema)
 
-async function getProps(context = {}) {
+async function getMarkdocData(context = {}) {
   const partials = {};
 
   // Ensure Node.transformChildren is available
@@ -159,12 +159,10 @@ async function getProps(context = {}) {
   // Removes undefined
   return JSON.parse(
     JSON.stringify({
-      markdoc: {
-        content,
-        frontmatter,
-        file: {
-          path: filepath
-        }
+      content,
+      frontmatter,
+      file: {
+        path: filepath,
       },
     })
   );
@@ -172,10 +170,10 @@ async function getProps(context = {}) {
 
 
 
-export default async function MarkdocComponent() {
-  const props = await getProps();
+export default async function MarkdocComponent(props = {}) {
+  const markdoc = await getMarkdocData();
   // Only execute HMR code in development
-  return renderers.react(props.markdoc.content, React, {
+  return renderers.react(markdoc.content, React, {
     components: {
       ...components,
       // Allows users to override default components at runtime, via their _app
@@ -219,7 +217,7 @@ const frontmatter = ast.attributes.frontmatter
 
 const {components, ...rest} = getSchema(schema)
 
-async function getProps(context = {}) {
+async function getMarkdocData(context = {}) {
   const partials = {};
 
   // Ensure Node.transformChildren is available
@@ -250,12 +248,10 @@ async function getProps(context = {}) {
   // Removes undefined
   return JSON.parse(
     JSON.stringify({
-      markdoc: {
-        content,
-        frontmatter,
-        file: {
-          path: filepath
-        }
+      content,
+      frontmatter,
+      file: {
+        path: filepath,
       },
     })
   );
@@ -263,14 +259,16 @@ async function getProps(context = {}) {
 
 export async function getStaticProps(context) {
   return {
-    props: await getProps(context),
+    props: {
+      markdoc: await getMarkdocData(context),
+    },
   };
 }
 
-export default function MarkdocComponent(props) {
-  
+export default function MarkdocComponent(props = {}) {
+  const markdoc = props.markdoc;
   // Only execute HMR code in development
-  return renderers.react(props.markdoc.content, React, {
+  return renderers.react(markdoc.content, React, {
     components: {
       ...components,
       // Allows users to override default components at runtime, via their _app

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -81,7 +81,7 @@ export async function getStaticProps(context) {
   };
 }
 
-export default function MarkdocComponent(props = {}) {
+export default function MarkdocComponent(props) {
   const markdoc = props.markdoc;
   // Only execute HMR code in development
   return renderers.react(markdoc.content, React, {
@@ -170,7 +170,7 @@ async function getMarkdocData(context = {}) {
 
 
 
-export default async function MarkdocComponent(props = {}) {
+export default async function MarkdocComponent(props) {
   const markdoc = await getMarkdocData();
   // Only execute HMR code in development
   return renderers.react(markdoc.content, React, {
@@ -265,7 +265,7 @@ export async function getStaticProps(context) {
   };
 }
 
-export default function MarkdocComponent(props = {}) {
+export default function MarkdocComponent(props) {
   const markdoc = props.markdoc;
   // Only execute HMR code in development
   return renderers.react(markdoc.content, React, {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -157,6 +157,26 @@ test('file output is correct', async () => {
   );
 });
 
+test('app router', async () => {
+  const output = await callLoader(options({ appDir: true }), source);
+
+  expect(normalizeOperatingSystemPaths(output)).toMatchSnapshot();
+
+  const page = evaluate(output);
+
+  expect(evaluate(output)).toEqual({
+    default: expect.any(Function),
+  });
+
+  expect(await page.default()).toEqual(
+    React.createElement(
+      'article',
+      undefined,
+      React.createElement('h1', undefined, 'Custom title')
+    )
+  );
+});
+
 test.each([
   [undefined, undefined],
   ['./schemas/folders', 'markdoc1'],

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -168,7 +168,7 @@ test('app router', async () => {
     default: expect.any(Function),
   });
 
-  expect(await page.default()).toEqual(
+  expect(await page.default({})).toEqual(
     React.createElement(
       'article',
       undefined,


### PR DESCRIPTION
This PR adds initial support for the [Next.js app router](https://nextjs.org/docs/app).

### Implementation

If the Next.js project is using the app router (i.e. `config.experimental.appDir` is `true`) then instead of outputting `getStaticProps`/`getServerSideProps` we make the `MarkdocComponent` component async and define the "props" directly in the function body:

```js
// Pages router
export default function MarkdocComponent(props) {
  // ...use `props`
}

export async function getStaticProps(context) {
  return {
    props: await getProps(context),
  }
}
```

```js
// App router
export default async function MarkdocComponent() {
  const props = await getProps()
  // ...use `props`
}
```

~Additionally, when using app router a [`metadata` export](https://nextjs.org/docs/app/building-your-application/optimizing/metadata) is added, allowing you to set the page title, description etc. using frontmatter:~ This will be done in a separate PR now

```js
export const metadata = frontmatter.metadata;
```

```md
---
metadata:
  title: My Page Title
---
```

### Not implemented

- [`props.components`](https://github.com/markdoc/next.js/blob/4a27eb1752f562febecf36b792fa629e57a1eb4e/src/loader.js#L204-L205) (_"Allows users to override default components at runtime, via their \_app"_) – ~in app router you don't have access to the component and therefore can't pass components as a prop, so I'm unsure how this could be supported~ Although you don't have access to the component when it's a page, you _can_ import a Markdoc component and then use the `components` prop (This is now supported by this PR):
  ```js
  import MarkdocComponent from './component.md'

  <MarkdocComponent components={{ /* ... */ }} />
  ```
- [`context.variables`](https://github.com/markdoc/next.js/blob/4a27eb1752f562febecf36b792fa629e57a1eb4e/src/loader.js#L170-L171) (_"Allows users to eject from Markdoc rendering and pass in dynamic variables via getServerSideProps"_) – I'm not 100% sure what this comment means or whether it needs to be supported in app router
- ~Accessing frontmatter outside the Markdoc component (e.g. [Layout example](https://markdoc.dev/docs/nextjs#layouts)) – again we don't have access to the component or its props in app router, so not sure what to do here~

~For the last point one idea I had was to pass the props to the `document` node:~

```diff
  return renderers.react(props.markdoc.content, React, {
    components: {
      ...components,
      // Allows users to override default components at runtime, via their _app
      ...props.components,
+     ...(components.Document
+       ? {
+         Document({ children }) {
+           return <components.Document {...props}>{children}</components.Document>;
+         }
+       }
+       : {}
+     ),
    },
  });
```

~Which would allow you to access the `markdoc` prop (containing `content`, `frontmatter` etc.) in your custom `document` node:~

```js
// nodes.js
export default {
  document: {
    render({ children, markdoc }) {
      console.log({ markdoc })
      return children
    },
  },
}
```

~I think this would cover most use-cases, such as having a "layout" for Markdoc documents that has access to frontmatter. Curious what you think of this idea!~

It seems the "layout" use-case is possible using a node `transform` function so maybe this is fine:

```js
import { Tag, nodes } from '@markdoc/markdoc'
import { Document } from '@/components/Document'
import yaml from 'js-yaml'

export default {
  ...nodes.document,
  render: Document,
  transform(node, config) {
    return new Tag(
      this.render,
      { frontmatter: yaml.load(node.attributes.frontmatter) },
      node.transformChildren(config)
    )
  },
}
```

---

Hopefully this PR is of some use! :) I'm happy to take any feedback and make any changes or additions that you can think of 👍 