### PR TITLE
Add support for Next.js app router exports

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -119,6 +119,23 @@ async function load(source) {
   }
 
   this.addContextDependency(schemaDir);
+
+  const nextjsExports = [
+    'dynamic',
+    'dynamicParams',
+    'fetchCache',
+    'maxDuration',
+    'metadata',
+    'preferredRegion',
+    'revalidate',
+    'runtime',
+  ]
+  const nextjsExportsCode = nextjsExports
+    .map((name) => {
+      return `export const ${name} = frontmatter.nextjs?.${name};`
+    })
+    .join('\n')
+
   const result = `import React from 'react';
 import yaml from 'js-yaml';
 // renderers is imported separately so Markdoc isn't sent to the client
@@ -206,9 +223,7 @@ ${
   };
 }`
 }
-
-${appDir ? `export const metadata = frontmatter.metadata;` : ''}
-
+${appDir ? nextjsExportsCode : ''}
 export default${appDir ? ' async' : ''} function MarkdocComponent(props) {
   const markdoc = ${appDir ? 'await getMarkdocData()' : 'props.markdoc'};
   // Only execute HMR code in development

--- a/src/loader.js
+++ b/src/loader.js
@@ -125,9 +125,7 @@ async function load(source) {
     'revalidate',
   ]
   const nextjsExportsCode = nextjsExports
-    .map((name) => {
-      return `export const ${name} = frontmatter.nextjs?.${name};`
-    })
+    .map((name) => `export const ${name} = frontmatter.nextjs?.${name};`)
     .join('\n')
 
   const result = `import React from 'react';

--- a/src/loader.js
+++ b/src/loader.js
@@ -203,6 +203,8 @@ ${appDir ? '' : `export async function ${dataFetchingFunction}(context) {
   };
 }`}
 
+${appDir ? `export const metadata = frontmatter.metadata;` : ''}
+
 export default${appDir ? ' async' : ''} function MarkdocComponent(props) {
   const markdoc = ${appDir ? 'await getMarkdocData()' : 'props.markdoc'};
   // Only execute HMR code in development

--- a/src/loader.js
+++ b/src/loader.js
@@ -121,14 +121,8 @@ async function load(source) {
   this.addContextDependency(schemaDir);
 
   const nextjsExports = [
-    'dynamic',
-    'dynamicParams',
-    'fetchCache',
-    'maxDuration',
     'metadata',
-    'preferredRegion',
     'revalidate',
-    'runtime',
   ]
   const nextjsExportsCode = nextjsExports
     .map((name) => {

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -81,6 +81,8 @@ export async function getStaticProps(context) {
   };
 }
 
+
+
 export default function MarkdocComponent(props) {
   const markdoc = props.markdoc;
   // Only execute HMR code in development
@@ -169,6 +171,99 @@ async function getMarkdocData(context = {}) {
 }
 
 
+
+export const metadata = frontmatter.metadata;
+
+export default async function MarkdocComponent(props) {
+  const markdoc = await getMarkdocData();
+  // Only execute HMR code in development
+  return renderers.react(markdoc.content, React, {
+    components: {
+      ...components,
+      // Allows users to override default components at runtime, via their _app
+      ...props.components,
+    },
+  });
+}
+"
+`;
+
+exports[`app router metadata 1`] = `
+"import React from 'react';
+import yaml from 'js-yaml';
+// renderers is imported separately so Markdoc isn't sent to the client
+import Markdoc, {renderers} from '@markdoc/markdoc'
+
+import {getSchema, defaultObject} from './src/runtime.js';
+/**
+ * Schema is imported like this so end-user's code is compiled using build-in babel/webpack configs.
+ * This enables typescript/ESnext support
+ */
+const schema = {};
+
+const tokenizer = new Markdoc.Tokenizer({\\"allowComments\\":true});
+
+/**
+ * Source will never change at runtime, so parse happens at the file root
+ */
+const source = \\"---\\\\nmetadata:\\\\n  title: Metadata title\\\\ntitle: Custom title\\\\n---\\\\n\\\\n# {% $markdoc.frontmatter.title %}\\\\n\\\\n{% tag /%}\\\\n\\";
+const filepath = undefined;
+const tokens = tokenizer.tokenize(source);
+const ast = Markdoc.parse(tokens, {slots: false});
+
+/**
+ * Like the AST, frontmatter won't change at runtime, so it is loaded at file root.
+ * This unblocks future features, such a per-page dataFetchingFunction.
+ */
+const frontmatter = ast.attributes.frontmatter
+  ? yaml.load(ast.attributes.frontmatter)
+  : {};
+
+const {components, ...rest} = getSchema(schema)
+
+async function getMarkdocData(context = {}) {
+  const partials = {};
+
+  // Ensure Node.transformChildren is available
+  Object.keys(partials).forEach((key) => {
+    const tokens = tokenizer.tokenize(partials[key]);
+    partials[key] = Markdoc.parse(tokens);
+  });
+
+  const cfg = {
+    ...rest,
+    variables: {
+      ...(rest ? rest.variables : {}),
+      // user can't override this namespace
+      markdoc: {frontmatter},
+      // Allows users to eject from Markdoc rendering and pass in dynamic variables via getServerSideProps
+      ...(context.variables || {})
+    },
+    partials,
+    source,
+  };
+
+  /**
+   * transform must be called in dataFetchingFunction to support server-side rendering while
+   * accessing variables on the server
+   */
+  const content = await Markdoc.transform(ast, cfg);
+
+  // Removes undefined
+  return JSON.parse(
+    JSON.stringify({
+      content,
+      frontmatter,
+      file: {
+        path: filepath,
+      },
+    })
+  );
+}
+
+
+
+export const metadata = frontmatter.metadata;
 
 export default async function MarkdocComponent(props) {
   const markdoc = await getMarkdocData();
@@ -264,6 +359,8 @@ export async function getStaticProps(context) {
     },
   };
 }
+
+
 
 export default function MarkdocComponent(props) {
   const markdoc = props.markdoc;

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -81,8 +81,6 @@ export async function getStaticProps(context) {
   };
 }
 
-
-
 export default function MarkdocComponent(props) {
   const markdoc = props.markdoc;
   // Only execute HMR code in development
@@ -171,100 +169,14 @@ async function getMarkdocData(context = {}) {
 }
 
 
-
-export const metadata = frontmatter.metadata;
-
-export default async function MarkdocComponent(props) {
-  const markdoc = await getMarkdocData();
-  // Only execute HMR code in development
-  return renderers.react(markdoc.content, React, {
-    components: {
-      ...components,
-      // Allows users to override default components at runtime, via their _app
-      ...props.components,
-    },
-  });
-}
-"
-`;
-
-exports[`app router metadata 1`] = `
-"import React from 'react';
-import yaml from 'js-yaml';
-// renderers is imported separately so Markdoc isn't sent to the client
-import Markdoc, {renderers} from '@markdoc/markdoc'
-
-import {getSchema, defaultObject} from './src/runtime.js';
-/**
- * Schema is imported like this so end-user's code is compiled using build-in babel/webpack configs.
- * This enables typescript/ESnext support
- */
-const schema = {};
-
-const tokenizer = new Markdoc.Tokenizer({\\"allowComments\\":true});
-
-/**
- * Source will never change at runtime, so parse happens at the file root
- */
-const source = \\"---\\\\nmetadata:\\\\n  title: Metadata title\\\\ntitle: Custom title\\\\n---\\\\n\\\\n# {% $markdoc.frontmatter.title %}\\\\n\\\\n{% tag /%}\\\\n\\";
-const filepath = undefined;
-const tokens = tokenizer.tokenize(source);
-const ast = Markdoc.parse(tokens, {slots: false});
-
-/**
- * Like the AST, frontmatter won't change at runtime, so it is loaded at file root.
- * This unblocks future features, such a per-page dataFetchingFunction.
- */
-const frontmatter = ast.attributes.frontmatter
-  ? yaml.load(ast.attributes.frontmatter)
-  : {};
-
-const {components, ...rest} = getSchema(schema)
-
-async function getMarkdocData(context = {}) {
-  const partials = {};
-
-  // Ensure Node.transformChildren is available
-  Object.keys(partials).forEach((key) => {
-    const tokens = tokenizer.tokenize(partials[key]);
-    partials[key] = Markdoc.parse(tokens);
-  });
-
-  const cfg = {
-    ...rest,
-    variables: {
-      ...(rest ? rest.variables : {}),
-      // user can't override this namespace
-      markdoc: {frontmatter},
-      // Allows users to eject from Markdoc rendering and pass in dynamic variables via getServerSideProps
-      ...(context.variables || {})
-    },
-    partials,
-    source,
-  };
-
-  /**
-   * transform must be called in dataFetchingFunction to support server-side rendering while
-   * accessing variables on the server
-   */
-  const content = await Markdoc.transform(ast, cfg);
-
-  // Removes undefined
-  return JSON.parse(
-    JSON.stringify({
-      content,
-      frontmatter,
-      file: {
-        path: filepath,
-      },
-    })
-  );
-}
-
-
-
-export const metadata = frontmatter.metadata;
-
+export const dynamic = frontmatter.nextjs?.dynamic;
+export const dynamicParams = frontmatter.nextjs?.dynamicParams;
+export const fetchCache = frontmatter.nextjs?.fetchCache;
+export const maxDuration = frontmatter.nextjs?.maxDuration;
+export const metadata = frontmatter.nextjs?.metadata;
+export const preferredRegion = frontmatter.nextjs?.preferredRegion;
+export const revalidate = frontmatter.nextjs?.revalidate;
+export const runtime = frontmatter.nextjs?.runtime;
 export default async function MarkdocComponent(props) {
   const markdoc = await getMarkdocData();
   // Only execute HMR code in development
@@ -359,8 +271,6 @@ export async function getStaticProps(context) {
     },
   };
 }
-
-
 
 export default function MarkdocComponent(props) {
   const markdoc = props.markdoc;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -183,14 +183,7 @@ test('app router metadata', async () => {
     source.replace('---', '---\nmetadata:\n  title: Metadata title')
   );
 
-  expect(normalizeOperatingSystemPaths(output)).toMatchSnapshot();
-
-  expect(evaluate(output)).toEqual({
-    default: expect.any(Function),
-    metadata: expect.objectContaining({
-      title: 'Metadata title',
-    }),
-  });
+  expect(output).toContain('export const metadata = frontmatter.nextjs?.metadata;')
 });
 
 test.each([

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -177,6 +177,22 @@ test('app router', async () => {
   );
 });
 
+test('app router metadata', async () => {
+  const output = await callLoader(
+    options({ appDir: true }),
+    source.replace('---', '---\nmetadata:\n  title: Metadata title')
+  );
+
+  expect(normalizeOperatingSystemPaths(output)).toMatchSnapshot();
+
+  expect(evaluate(output)).toEqual({
+    default: expect.any(Function),
+    metadata: expect.objectContaining({
+      title: 'Metadata title',
+    }),
+  });
+});
+
 test.each([
   [undefined, undefined],
   ['./schemas/folders', 'markdoc1'],


### PR DESCRIPTION
Ref: https://github.com/markdoc/markdoc/issues/416, https://github.com/markdoc/markdoc/issues/418

This PR adds support for specifying the `metadata` and `revalidate` exports when using app router:

```md
---
nextjs:
  metadata:
    title: Lorem ipsum
    description: Lorem ipsum dolor sit amet
  revalidate: 60
---
```

Closes https://github.com/markdoc/markdoc/issues/418
Closes https://github.com/markdoc/markdoc/issues/416