### PR TITLE
add: ability to wrap markdoc in layout

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,6 +28,7 @@ export interface MarkdocNextJsOptions {
     allowComments?: boolean;
   };
   schemaPath?: string;
+  layoutPath?: string;
 }
 
 declare function createMarkdocPlugin(


### PR DESCRIPTION
This fixes https://github.com/markdoc/markdoc/discussions/329, where on upgrading to the app directory structure for Next JS it's impossible to get the context of the markdoc prop outside of the markdoc component itself making it near impossible to do things like creating table of contents, sidebars, etc.

This PR takes the approach I've used on my project which creates a "layout" component that wraps markdoc components allowing you to insert the markdoc context into an outer wrapper which can contain table of contents components etc.

This effectively gives you the same flexibility as the pages router did.