### PR TITLE
Export markdoc object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@markdoc/next.js",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@markdoc/next.js",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdoc/next.js",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "author": "Stripe, Inc.",
   "description": "Markdoc plugin for Next.js",
   "license": "MIT",

--- a/src/loader.js
+++ b/src/loader.js
@@ -222,6 +222,7 @@ ${
 }`
 }
 ${appDir ? nextjsExportsCode : ''}
+export const markdoc = {frontmatter};
 export default${appDir ? ' async' : ''} function MarkdocComponent(props) {
   const markdoc = ${appDir ? 'await getMarkdocData()' : 'props.markdoc'};
   // Only execute HMR code in development

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -82,6 +82,7 @@ export async function getStaticProps(context) {
   };
 }
 
+export const markdoc = {frontmatter};
 export default function MarkdocComponent(props) {
   const markdoc = props.markdoc;
   // Only execute HMR code in development
@@ -173,6 +174,7 @@ async function getMarkdocData(context = {}) {
 
 export const metadata = frontmatter.nextjs?.metadata;
 export const revalidate = frontmatter.nextjs?.revalidate;
+export const markdoc = {frontmatter};
 export default async function MarkdocComponent(props) {
   const markdoc = await getMarkdocData();
   // Only execute HMR code in development
@@ -269,6 +271,7 @@ export async function getStaticProps(context) {
   };
 }
 
+export const markdoc = {frontmatter};
 export default function MarkdocComponent(props) {
   const markdoc = props.markdoc;
   // Only execute HMR code in development

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -123,6 +123,11 @@ test('file output is correct', async () => {
   expect(evaluate(output)).toEqual({
     default: expect.any(Function),
     getStaticProps: expect.any(Function),
+    markdoc: {
+      frontmatter: {
+        title: 'Custom title',
+      },
+    },
   });
 
   const data = await page.getStaticProps({});
@@ -158,7 +163,7 @@ test('file output is correct', async () => {
 });
 
 test('app router', async () => {
-  const output = await callLoader(options({ appDir: true }), source);
+  const output = await callLoader(options({appDir: true}), source);
 
   expect(normalizeOperatingSystemPaths(output)).toMatchSnapshot();
 
@@ -166,6 +171,11 @@ test('app router', async () => {
 
   expect(evaluate(output)).toEqual({
     default: expect.any(Function),
+    markdoc: {
+      frontmatter: {
+        title: 'Custom title',
+      },
+    },
   });
 
   expect(await page.default({})).toEqual(
@@ -179,11 +189,13 @@ test('app router', async () => {
 
 test('app router metadata', async () => {
   const output = await callLoader(
-    options({ appDir: true }),
+    options({appDir: true}),
     source.replace('---', '---\nmetadata:\n  title: Metadata title')
   );
 
-  expect(output).toContain('export const metadata = frontmatter.nextjs?.metadata;')
+  expect(output).toContain(
+    'export const metadata = frontmatter.nextjs?.metadata;'
+  );
 });
 
 test.each([
@@ -248,5 +260,10 @@ test('mode="server"', async () => {
   expect(evaluate(output)).toEqual({
     default: expect.any(Function),
     getServerSideProps: expect.any(Function),
+    markdoc: {
+      frontmatter: {
+        title: 'Custom title',
+      },
+    },
   });
 });


### PR DESCRIPTION
This would allow end users do something like:
```js
import {markdoc} from './pages/writing/my-blog-post.md'
```

e.g. to include all the titles in a blog index. 

Closes https://github.com/markdoc/next.js/pull/49