### PR TITLE
Allow overriding appDir as an escape hatch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,10 @@ const withMarkdoc =
             {
               loader: require.resolve('./loader'),
               options: {
+                appDir: options.defaultLoaders.babel.options.appDir,
                 ...pluginOptions,
                 dir: options.dir,
                 nextRuntime: options.nextRuntime,
-                appDir: options.defaultLoaders.babel.options.appDir,
               },
             },
           ],


### PR DESCRIPTION
Closes https://github.com/markdoc/markdoc/issues/451