### PR TITLE
Fix invalid default export type declaration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,4 +34,4 @@ declare function createMarkdocPlugin(
   options?: MarkdocNextJsOptions
 ): (config: NextConfig) => NextConfig;
 
-export default createMarkdocPlugin;
+export = createMarkdocPlugin;


### PR DESCRIPTION
I bumped into an issue when attempting to use @markdoc/next.js 0.3.7 in a Next.js application.

next.config.js contents:

    //@ts-check

    // eslint-disable-next-line @typescript-eslint/no-var-requires
    const { composePlugins, withNx } = require('@nx/next')

    const withMarkdoc = require('@markdoc/next.js')

    /**
     * @type {import('@nx/next/plugins/with-nx').WithNxOptions} **/ const nextConfig = { nx: { // Set this to true if you would like to use SVGR // See: https://github.com/gregberge/svgr svgr: false, }, pageExtensions: ['mdoc'], }

    const plugins = [
        // Add more Next.js plugins to this list if needed.
        withNx,
    ]

    module.exports = composePlugins(...plugins)(withMarkdoc()(nextConfig))

Attempting to build the project failed with

      ▲ Next.js 14.2.15

       Skipping linting
       Checking validity of types  .Failed to compile.

    ./next.config.js:25:45
    Type error: This expression is not callable.
      Type 'typeof import("/lune/lune-fe/apps/docs/node_modules/@markdoc/next.js/src/index")' has no call signatures.

      23 | ]
      24 |
    > 25 | module.exports = composePlugins(...plugins)(withMarkdoc()(nextConfig))
         |                                             ^
      26 |

arethetypeswrong says the 0.3.7 types are indeed wrong[1]:

    Incorrect default export

    The resolved types use export default where the JavaScript file
    appears to use module.exports =. This will cause TypeScript under
    the node16 module mode to think an extra .default property access is
    required, but that will likely fail at runtime. These types should
    use export = instead of export default.

[2] says that if the .js file uses "module.exports = ..." syntax the .d.ts file should say "export = ...".

With this change the Next.js project I'm working on builds successfully and arethetypeswrong is happy.

[1] https://arethetypeswrong.github.io/?p=%40markdoc%2Fnext.js%400.3.7
[2] https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/fcb426886791997e20b98225ba5ccd7f77dfc6d9/docs/problems/FalseExportDefault.md