### PR TITLE
Support loading Markdoc components client side

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const withMarkdoc =
               loader: require.resolve('./loader'),
               options: {
                 appDir: options.defaultLoaders.babel.options.appDir,
+                pagesDir: options.defaultLoaders.babel.options.pagesDir,
                 ...pluginOptions,
                 dir: options.dir,
                 nextRuntime: options.nextRuntime,

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -116,7 +116,7 @@ const tokenizer = new Markdoc.Tokenizer({\\"allowComments\\":true});
  * Source will never change at runtime, so parse happens at the file root
  */
 const source = \\"---\\\\ntitle: Custom title\\\\n---\\\\n\\\\n# {% $markdoc.frontmatter.title %}\\\\n\\\\n{% tag /%}\\\\n\\";
-const filepath = undefined;
+const filepath = \\"/test/index.md\\";
 const tokens = tokenizer.tokenize(source);
 const parseOptions = {\\"slots\\":false};
 const ast = Markdoc.parse(tokens, parseOptions);

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -285,3 +285,94 @@ export default function MarkdocComponent(props) {
 }
 "
 `;
+
+exports[`import as frontend component 1`] = `
+"import React from 'react';
+import yaml from 'js-yaml';
+// renderers is imported separately so Markdoc isn't sent to the client
+import Markdoc, {renderers} from '@markdoc/markdoc'
+
+import {getSchema, defaultObject} from './src/runtime.js';
+/**
+ * Schema is imported like this so end-user's code is compiled using build-in babel/webpack configs.
+ * This enables typescript/ESnext support
+ */
+const schema = {};
+
+const tokenizer = new Markdoc.Tokenizer({\\"allowComments\\":true});
+
+/**
+ * Source will never change at runtime, so parse happens at the file root
+ */
+const source = \\"---\\\\ntitle: Custom title\\\\n---\\\\n\\\\n# {% $markdoc.frontmatter.title %}\\\\n\\\\n{% tag /%}\\\\n\\";
+const filepath = undefined;
+const tokens = tokenizer.tokenize(source);
+const parseOptions = {\\"slots\\":false};
+const ast = Markdoc.parse(tokens, parseOptions);
+
+/**
+ * Like the AST, frontmatter won't change at runtime, so it is loaded at file root.
+ * This unblocks future features, such a per-page dataFetchingFunction.
+ */
+const frontmatter = ast.attributes.frontmatter
+  ? yaml.load(ast.attributes.frontmatter)
+  : {};
+
+const {components, ...rest} = getSchema(schema)
+
+function getMarkdocData(context = {}) {
+  const partials = {};
+
+  // Ensure Node.transformChildren is available
+  Object.keys(partials).forEach((key) => {
+    const tokens = tokenizer.tokenize(partials[key]);
+    partials[key] = Markdoc.parse(tokens, parseOptions);
+  });
+
+  const cfg = {
+    ...rest,
+    variables: {
+      ...(rest ? rest.variables : {}),
+      // user can't override this namespace
+      markdoc: {frontmatter},
+      // Allows users to eject from Markdoc rendering and pass in dynamic variables via getServerSideProps
+      ...(context.variables || {})
+    },
+    partials,
+    source,
+  };
+
+  /**
+   * transform must be called in dataFetchingFunction to support server-side rendering while
+   * accessing variables on the server
+   */
+  const content = Markdoc.transform(ast, cfg);
+
+  // Removes undefined
+  return JSON.parse(
+    JSON.stringify({
+      content,
+      frontmatter,
+      file: {
+        path: filepath,
+      },
+    })
+  );
+}
+
+
+
+export const markdoc = {frontmatter};
+export default function MarkdocComponent(props) {
+  const markdoc = getMarkdocData();
+  // Only execute HMR code in development
+  return renderers.react(markdoc.content, React, {
+    components: {
+      ...components,
+      // Allows users to override default components at runtime, via their _app
+      ...props.components,
+    },
+  });
+}
+"
+`;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -59,6 +59,8 @@ function evaluate(output) {
 }
 
 function options(config = {}) {
+  const dir = `${'/Users/someone/a-next-js-repo'}/${config.appDir ? 'app' : 'pages'}`;
+
   const webpackThis = {
     context: __dirname,
     getOptions() {
@@ -66,6 +68,8 @@ function options(config = {}) {
         ...config,
         dir: __dirname,
         nextRuntime: 'nodejs',
+        appDir: config.appDir ? dir : undefined,
+        pagesDir: config.appDir ? undefined : dir,
       };
     },
     getLogger() {
@@ -77,12 +81,10 @@ function options(config = {}) {
       const resolve = enhancedResolve.create(options);
       return async (context, file) =>
         new Promise((res, rej) =>
-          resolve(context, file, (err, result) =>
-            err ? rej(err) : res(result)
-          )
+          resolve(context, file, (err, result) => (err ? rej(err) : res(result)))
         ).then(normalizeAbsolutePath);
     },
-    resourcePath: '/Users/someone/a-next-js-repo/pages/test/index.md',
+    resourcePath: dir + '/test/index.md',
   };
 
   return webpackThis;
@@ -102,15 +104,13 @@ async function callLoader(config, source) {
 }
 
 test('should not fail build if default `schemaPath` is used', async () => {
-  await expect(callLoader(options(), source)).resolves.toEqual(
-    expect.any(String)
-  );
+  await expect(callLoader(options(), source)).resolves.toEqual(expect.any(String));
 });
 
 test('should fail build if invalid `schemaPath` is used', async () => {
-  await expect(
-    callLoader(options({schemaPath: 'unknown_schema_path'}), source)
-  ).rejects.toThrow("Cannot find module 'unknown_schema_path'");
+  await expect(callLoader(options({schemaPath: 'unknown_schema_path'}), source)).rejects.toThrow(
+    "Cannot find module 'unknown_schema_path'"
+  );
 });
 
 test('file output is correct', async () => {
@@ -154,11 +154,7 @@ test('file output is correct', async () => {
   });
 
   expect(page.default(data.props)).toEqual(
-    React.createElement(
-      'article',
-      undefined,
-      React.createElement('h1', undefined, 'Custom title')
-    )
+    React.createElement('article', undefined, React.createElement('h1', undefined, 'Custom title'))
   );
 });
 
@@ -179,11 +175,7 @@ test('app router', async () => {
   });
 
   expect(await page.default({})).toEqual(
-    React.createElement(
-      'article',
-      undefined,
-      React.createElement('h1', undefined, 'Custom title')
-    )
+    React.createElement('article', undefined, React.createElement('h1', undefined, 'Custom title'))
   );
 });
 
@@ -193,9 +185,7 @@ test('app router metadata', async () => {
     source.replace('---', '---\nmetadata:\n  title: Metadata title')
   );
 
-  expect(output).toContain(
-    'export const metadata = frontmatter.nextjs?.metadata;'
-  );
+  expect(output).toContain('export const metadata = frontmatter.nextjs?.metadata;');
 });
 
 test.each([
@@ -211,9 +201,7 @@ test.each([
   const page = evaluate(output);
 
   const data = await page.getStaticProps({});
-  expect(data.props.markdoc.content.children[0].children[0]).toEqual(
-    'Custom title'
-  );
+  expect(data.props.markdoc.content.children[0].children[0]).toEqual('Custom title');
   expect(data.props.markdoc.content.children[1]).toEqual(expectedChild);
 });
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -255,3 +255,12 @@ test('mode="server"', async () => {
     },
   });
 });
+
+test('import as frontend component', async () => {
+  const o = options();
+  // Use a non-page pathway
+  o.resourcePath = o.resourcePath.replace('pages/test/index.md', 'components/table.md');
+  const output = await callLoader(o, source);
+
+  expect(normalizeOperatingSystemPaths(output)).toMatchSnapshot();
+});


### PR DESCRIPTION
PTAL @matv-stripe @segphault. This supports use cases where  you want to import a partial, or part of a document, from a React component in a Next.js app, where then the Markdoc transform and render would occur client side. 