### PR TITLE
Revert "Enhance Turbopack support and improve loader functionality"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,10 @@ The first thing you'll need to do is install `@markdoc/next.js` and add it to yo
    // next.config.js
    module.exports = withMarkdoc({
      dir: process.cwd(), // Required for Turbopack file resolution
-     schemaPath: './markdoc', // Wherever your Markdoc schema lives
    })({
      pageExtensions: ['js', 'md'],
-     turbopack: {}, // Turbopack only runs the loader when a base config exists
    });
    ```
-
-   Turbopack currently requires every schema entry file referenced by `schemaPath` to exist,
-   even if you are not customizing them yet. Create `config.js`, `nodes.js`, `tags.js`, and
-   `functions.js` in that directory (exporting empty objects is fine) so the loader can resolve
-   them during the build.
 
 3. Create a new Markdoc file in `pages/docs` named `getting-started.md`.
 


### PR DESCRIPTION
Reverts markdoc/next.js#67

Reverting this PR because [windows test CI](https://github.com/markdoc/next.js/actions/runs/20045100170/job/57942335634) is failing and for some reason was skipped in the original PR.

<img width="860" height="413" alt="image" src="https://github.com/user-attachments/assets/f696db18-e85c-4e9a-8f14-60163e875d31" />
