### PR TITLE
Enhance Turbopack support and improve loader functionality (retry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,17 @@ The first thing you'll need to do is install `@markdoc/next.js` and add it to yo
    // next.config.js
    module.exports = withMarkdoc({
      dir: process.cwd(), // Required for Turbopack file resolution
+     schemaPath: './markdoc', // Wherever your Markdoc schema lives
    })({
      pageExtensions: ['js', 'md'],
+     turbopack: {}, // Turbopack only runs the loader when a base config exists
    });
    ```
+
+   Turbopack currently requires every schema entry file referenced by `schemaPath` to exist,
+   even if you are not customizing them yet. Create `config.js`, `nodes.js`, `tags.js`, and
+   `functions.js` in that directory (exporting empty objects is fine) so the loader can resolve
+   them during the build.
 
 3. Create a new Markdoc file in `pages/docs` named `getting-started.md`.
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -8,6 +8,16 @@ function normalize(s) {
   return s.replace(/\\/g, path.win32.sep.repeat(2));
 }
 
+function getRelativeImportPath(from, to) {
+  const relative = path.relative(path.dirname(from), to);
+  if (!relative) {
+    return './';
+  }
+
+  const request = relative.startsWith('.') ? relative : `./${relative}`;
+  return normalize(request);
+}
+
 async function gatherPartials(ast, schemaDir, tokenizer, parseOptions) {
   let partials = {};
 
@@ -67,7 +77,7 @@ async function load(source) {
   const ast = Markdoc.parse(tokens, parseOptions);
 
   // Determine if this is a page file by checking if it starts with the provided directories
-  const isPage = (appDir && this.resourcePath.startsWith(appDir)) || 
+  const isPage = (appDir && this.resourcePath.startsWith(appDir)) ||
                  (pagesDir && this.resourcePath.startsWith(pagesDir));
 
   // Grabs the path of the file relative to the `/{app,pages}` directory
@@ -93,14 +103,34 @@ async function load(source) {
     const directoryExists = await fs.promises.stat(schemaDir);
 
     // This creates import strings that cause the config to be imported runtime
-    async function importAtRuntime(variable) {
-      try {
-        const module = await resolve(schemaDir, variable);
-        return `import * as ${variable} from '${normalize(module)}'`;
-      } catch (error) {
-        return `const ${variable} = {};`;
+    const importAtRuntime = async (variable) => {
+      const requests = [variable];
+
+      // Turbopack module resolution currently requires explicit relative paths
+      // when `preferRelative` is used with bare specifiers (e.g. `tags`).
+      if (
+        typeof variable === 'string' &&
+        !variable.startsWith('.') &&
+        !variable.startsWith('/')
+      ) {
+        requests.push(`./${variable}`);
       }
-    }
+
+      let lastError;
+
+      for (const request of requests) {
+        try {
+          const module = await resolve(schemaDir, request);
+          const modulePath = getRelativeImportPath(this.resourcePath, module);
+          return `import * as ${variable} from '${modulePath}'`;
+        } catch (error) {
+          lastError = error;
+        }
+      }
+
+      console.debug('[Markdoc loader] Failed to resolve', { schemaDir, variable, error: lastError });
+      return `const ${variable} = {};`;
+    };
 
     if (directoryExists) {
       schemaCode = `

--- a/src/loader.js
+++ b/src/loader.js
@@ -4,18 +4,17 @@ const Markdoc = require('@markdoc/markdoc');
 
 const DEFAULT_SCHEMA_PATH = './markdoc';
 
-function normalize(s) {
-  return s.replace(/\\/g, path.win32.sep.repeat(2));
-}
-
 function getRelativeImportPath(from, to) {
   const relative = path.relative(path.dirname(from), to);
   if (!relative) {
     return './';
   }
 
-  const request = relative.startsWith('.') ? relative : `./${relative}`;
-  return normalize(request);
+  // Module specifiers must use forward slashes on all platforms.
+  // Backslashes (or escaped versions) cause different loader output per OS
+  // and are not treated as path delimiters by bundlers.
+  const request = relative.split(path.sep).join(path.posix.sep);
+  return request.startsWith('.') ? request : `./${request}`;
 }
 
 async function gatherPartials(ast, schemaDir, tokenizer, parseOptions) {
@@ -85,7 +84,12 @@ async function load(source) {
   // This array access @ index 1 is safe since Next.js guarantees that
   // all pages will be located under either {app,pages}/ or src/{app,pages}/
   // https://nextjs.org/docs/app/building-your-application/configuring/src-directory
-  const filepath = this.resourcePath.split(appDir ? 'app' : 'pages')[1];
+  // Normalize to posix separators for consistent output across platforms.
+  // Undefined for non-page resources (e.g., .md imported as components).
+  const rawFilepath = this.resourcePath.split(appDir ? 'app' : 'pages')[1];
+  const filepath = rawFilepath
+    ? rawFilepath.split(path.sep).join(path.posix.sep)
+    : rawFilepath;
 
   const partials = await gatherPartials.call(
     this,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -338,8 +338,12 @@ test('mode="server"', async () => {
 
 test('import as frontend component', async () => {
   const o = options();
-  // Use a non-page pathway
-  o.resourcePath = o.resourcePath.replace('pages/test/index.md', 'components/table.md');
+  // Use a non-page pathway (join with OS-native separators so the replace
+  // also matches the backslash resourcePath on Windows)
+  o.resourcePath = o.resourcePath.replace(
+    path.join('pages', 'test', 'index.md'),
+    path.join('components', 'table.md')
+  );
   const output = await callLoader(o, source);
 
   expect(normalizeOperatingSystemPaths(output)).toMatchSnapshot();


### PR DESCRIPTION
Retries https://github.com/markdoc/next.js/pull/67 because CI actions were not triggered in the original PR and failed post-merge.

@DeeeeLAN can you try running `npm run test -- -u` to update jest snapshots if you're working on a windows machine? It doesn't change anything on macos and CI fails for the windows test builds. Thanks!