### PR TITLE
Fix Windows CI for the Turbopack loader changes

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -4,18 +4,19 @@ const Markdoc = require('@markdoc/markdoc');
 
 const DEFAULT_SCHEMA_PATH = './markdoc';
 
-function normalize(s) {
-  return s.replace(/\\/g, path.win32.sep.repeat(2));
-}
-
 function getRelativeImportPath(from, to) {
   const relative = path.relative(path.dirname(from), to);
   if (!relative) {
     return './';
   }
 
-  const request = relative.startsWith('.') ? relative : `./${relative}`;
-  return normalize(request);
+  // Module specifiers always use forward slashes, on every platform.
+  // Emitting Windows separators (or escaping them, as the old `normalize`
+  // helper did for absolute paths) produces per-OS-different loader output —
+  // the Windows snapshot failure that got #67 reverted — and separators that
+  // bundlers do not treat as path delimiters.
+  const request = relative.split(path.sep).join(path.posix.sep);
+  return request.startsWith('.') ? request : `./${request}`;
 }
 
 async function gatherPartials(ast, schemaDir, tokenizer, parseOptions) {
@@ -85,7 +86,13 @@ async function load(source) {
   // This array access @ index 1 is safe since Next.js guarantees that
   // all pages will be located under either {app,pages}/ or src/{app,pages}/
   // https://nextjs.org/docs/app/building-your-application/configuring/src-directory
-  const filepath = this.resourcePath.split(appDir ? 'app' : 'pages')[1];
+  // Normalized to posix separators so the emitted `path` value is identical
+  // on every platform (Windows resourcePaths contain backslashes). Undefined
+  // for resources outside {app,pages}/, e.g. .md files imported as components.
+  const rawFilepath = this.resourcePath.split(appDir ? 'app' : 'pages')[1];
+  const filepath = rawFilepath
+    ? rawFilepath.split(path.sep).join(path.posix.sep)
+    : rawFilepath;
 
   const partials = await gatherPartials.call(
     this,

--- a/src/loader.js
+++ b/src/loader.js
@@ -10,11 +10,9 @@ function getRelativeImportPath(from, to) {
     return './';
   }
 
-  // Module specifiers always use forward slashes, on every platform.
-  // Emitting Windows separators (or escaping them, as the old `normalize`
-  // helper did for absolute paths) produces per-OS-different loader output —
-  // the Windows snapshot failure that got #67 reverted — and separators that
-  // bundlers do not treat as path delimiters.
+  // Module specifiers must use forward slashes on all platforms.
+  // Backslashes (or escaped versions) cause different loader output per OS
+  // and are not treated as path delimiters by bundlers.
   const request = relative.split(path.sep).join(path.posix.sep);
   return request.startsWith('.') ? request : `./${request}`;
 }
@@ -86,9 +84,8 @@ async function load(source) {
   // This array access @ index 1 is safe since Next.js guarantees that
   // all pages will be located under either {app,pages}/ or src/{app,pages}/
   // https://nextjs.org/docs/app/building-your-application/configuring/src-directory
-  // Normalized to posix separators so the emitted `path` value is identical
-  // on every platform (Windows resourcePaths contain backslashes). Undefined
-  // for resources outside {app,pages}/, e.g. .md files imported as components.
+  // Normalize to posix separators for consistent output across platforms.
+  // Undefined for non-page resources (e.g., .md imported as components).
   const rawFilepath = this.resourcePath.split(appDir ? 'app' : 'pages')[1];
   const filepath = rawFilepath
     ? rawFilepath.split(path.sep).join(path.posix.sep)

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -338,8 +338,12 @@ test('mode="server"', async () => {
 
 test('import as frontend component', async () => {
   const o = options();
-  // Use a non-page pathway
-  o.resourcePath = o.resourcePath.replace('pages/test/index.md', 'components/table.md');
+  // Use a non-page pathway (join with OS-native separators so the replace
+  // also matches the backslash resourcePath on Windows)
+  o.resourcePath = o.resourcePath.replace(
+    path.join('pages', 'test', 'index.md'),
+    path.join('components', 'table.md')
+  );
   const output = await callLoader(o, source);
 
   expect(normalizeOperatingSystemPaths(output)).toMatchSnapshot();


### PR DESCRIPTION
This targets the #70 retry branch and fixes the `windows-latest` CI failure that got #67 reverted in #69 — without updating any snapshots. The failures turned out to be three real cross-platform bugs, so `npm run test -- -u` on Windows would have masked them (and produced snapshots that fail on Linux):

1. **`getRelativeImportPath` emitted OS-native separators.** `path.relative` produces backslashes on Windows and the old `normalize()` helper double-escaped them into the emitted import specifiers — making loader output differ per OS (the snapshot failures) and emitting separators bundlers don't treat as path delimiters. Now converts to posix separators, so emitted code is byte-identical on every platform; the previously-unused `normalize()` helper is removed.
2. **The emitted `path` metadata carried backslashes on Windows** (`this.resourcePath.split('pages')[1]`), failing the cross-platform `toEqual` assertions #67 added and shipping OS-dependent path values to the app. Normalized to posix, with a guard for non-page resources (e.g. `.md` imported as a component) where the split yields `undefined`.
3. **A test bug:** the `import as frontend component` test replaced a posix-joined substring inside a `path.join`-built resourcePath, which never matches on Windows — so on Windows that test silently exercised the *page* pathway.

**Proof:** this exact CI matrix passes on both platforms on my fork: [ubuntu + windows green](https://github.com/esetnik/markdoc-nextjs/actions/runs/28862936486) (vs [the branch without these fixes failing windows](https://github.com/esetnik/markdoc-nextjs/actions/runs/28862350747)). All 18 tests / 4 snapshots pass unmodified.

Context: we run `@markdoc/next.js` on Next 16 under Turbopack in production (via a local shim replicating #67's resolution fixes) and would love to retire the shim when 0.6.0 (#68) ships — happy to adjust anything here.

_Authored with Claude (AI) under my direction and review; commits carry co-author attribution._